### PR TITLE
[fix] Allow special characters in email adresses (fix #33)

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -592,7 +592,8 @@ function edit_user ()
                  ldap:close()
 
                  local rex = require "rex_pcre"
-                 local mail_re = rex.new([[^[\w\.\-]+@([^\W_A-Z]+([\-]*[^\W_A-Z]+)*\.)+([^\W\d_]{2,})$]], rex.flags().UTF8)
+                 local rex_flags = rex.flags()
+                 local mail_re = rex.new([[^[\w\.-+%]+@([^\W_A-Z]+([\-]*[^\W_A-Z]+)*\.)+([^\W\d_]{2,})$]], rex_flags.UTF8 + rex_flags.UCP)
 
                  local mails = {}
 


### PR DESCRIPTION
- Allow some special characters - but some of them are still missing: https://en.wikipedia.org/wiki/Email_address#Local_part
- Fix ignored Unicode characters by using Unicode properties in PCRE (fix https://github.com/Kloadut/SSOwat/issues/33)
