### PR TITLE
Regex non reconnues sur protected_regex

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -210,8 +210,8 @@ function is_protected()
         end
     end
     for _, regex in ipairs(conf["protected_regex"]) do
-        if string.match(ngx.var.host..ngx.var.uri, regex)
-        or string.match(ngx.var.uri, regex) then
+        if string.match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
+        or string.match(ngx.var.uri..hlp.uri_args_string(), regex) then
             return true
         end
     end


### PR DESCRIPTION
Les patterns sont interprétés correctement sur unprotected_regex, mais pas sur protected_regex.
L'ajout de ..hlp.uri_args_string() corrige ça et permet d'interpréter correctement les patterns
