### PR TITLE
Add the autofocus attribute to the username field

### DIFF
--- a/portal/login.html
+++ b/portal/login.html
@@ -2,7 +2,7 @@
 <form class="login-form" name="input" action="" method="post">
   <div class="form-group">
     <label class="icon icon-user" for="user"><span class="element-invisible">{{t_username}}</span></label>
-    <input id="user" type="text" name="user" placeholder="{{t_username}}" class="form-text" required>
+    <input id="user" type="text" name="user" placeholder="{{t_username}}" class="form-text" autofocus required>
   </div>
   <div class="form-group">
     <label class="icon icon-lock" for="password"><span class="element-invisible">{{t_password}}</span></label>


### PR DESCRIPTION
With the `autofocus` attribute, the field has the focus when the page is loaded. This mean that you don't need to click in the field to start writing your username.
