### PR TITLE
[fix] check users ACL on http basic auth

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -373,6 +373,12 @@ if auth_header then
     user = hlp.authenticate(user, password)
     if user then
         hlp.set_headers(user)
+
+        -- If user has no access to this URL, redirect him to the portal
+        if not hlp.has_access(user) then
+            return hlp.redirect(conf.portal_url)
+        end
+
         return hlp.pass()
     end
 end


### PR DESCRIPTION
Related ticket https://dev.yunohost.org/issues/918

ACL weren't checked on http basic auth.