### PR TITLE
[fix] uses a cryptographically secure source of randomness

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -27,12 +27,17 @@ local config = require "config"
 flashs = {}
 i18n = {}
 
+-- convert a string to a hex
+function tohex(str)
+    return (str:gsub('.', function (c)
+        return string.format('%02X', string.byte(c))
+    end))
+end
+
 -- Efficient function to get a random string
 function random_string()
-    math.randomseed( tonumber(tostring(socket.gettime()*10000):reverse()) )
-    str = tostring(math.random()):sub(3)
-    socket.sleep(1e-400)
-    return str
+    local random_bytes = io.open("/dev/urandom"):read(64);
+    return tohex(random_bytes);
 end
 
 -- Load translations in the "i18n" above table


### PR DESCRIPTION
Our current solution to grab a random number as a key is bad, it doesn't uses a safe cryptographic source of randomness, this commit fixes that using urandom.

Prosody seems to be using urandom too and it's the generally recommended source of randomness (well, except if we were to uses openssl binding for lua, but this ecosystem is a such fucking disaster that I didn't managed to play with it and lua-ffi only works on x86/x64 -_-)

I'm converting the result to an hex string to avoid weird char problems as this string is often concatenated around and other stuff (and for a next pr).

The number 64 is totally arbitrary and probably way way too big, I'm trying to get feedback from a friend on that (and from nicoo but he hasn't aswered to my IRC query).

We should not wait too much to merge and release that because security.
