### PR TITLE
skipped_urls is mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you use YunoHost, you may want to edit the `/etc/ssowat/conf.json.persistent`
 
 ## Available parameters
 
-These are the SSOwat's configuration parameters. Only the first one is required, but it is recommended to know the others to fully understand what you can do with SSOwat.
+These are the SSOwat's configuration parameters. Only `portal_domain` and `skipped_urls` are required, but it is recommended to know the others to fully understand what you can do with SSOwat.
 
 #### portal_domain
 
@@ -134,7 +134,7 @@ List of regular expressions to be matched against URLs **and** URIs to protect t
 
 #### skipped_urls
 
-List of URLs and/or URIs that will not be affected by SSOwat
+List of URLs and/or URIs that will not be affected by SSOwat. This must be a JSON array, and SSOwat automatically adds itself to this array.
 
 #### skipped_regex
 


### PR DESCRIPTION
Else we get this error:
```
2017/09/16 13:48:38 [error] 31132#31132: *10 lua entry thread aborted: runtime error: /etc/ssowat/config.lua:81: bad argument #1 to 'insert' (table expected, got nil)                                          
stack traceback:                                            
coroutine 0:                                                
        [C]: in function 'insert'                           
        /etc/ssowat/config.lua:81: in function 'get_config' 
        /etc/ssowat/access.lua:20: in function </etc/ssowat/access.lua:1>, client: 192.168.1.99, server: , request: "GET /cms/ HTTP/1.1", host: "yalis.fr"
```