### PR TITLE
1º Let the admin choose if the passwords should be overwriten using crypt; 2º minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you use YunoHost, you may want to edit the `/etc/ssowat/conf.json.persistent`
 
 ## Available parameters
 
-These are the SSOwat's configuration parameters. Only `portal_domain` and `skipped_urls` are required, but it is recommended to know the others to fully understand what you can do with SSOwat.
+These are the SSOwat's configuration parameters. Only `portal_domain` is required, but it is recommended to know the others to fully understand what you can do with SSOwat.
 
 #### portal_domain
 
@@ -103,6 +103,10 @@ LDAP user identifier (**default**: `uid`)
 #### ldap_attributes
 
 User's attributes to fetch from LDAP (**default**: `["uid", "givenname", "sn", "cn", "homedirectory", "mail", "maildrop"]`)
+
+#### ldap_enforce_crypt
+
+Let SSOwat re-encrypt weakly-encrypted LDAP passwords into the safer sha-512 (crypt) (**default**: `true`)
 
 #### allow_mail_authentication
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ Domain of the authentication portal. It has to be a domain, IP addresses will no
 
 #### portal_path
 
-URI of the authentication portal (**default**: `/ssowat`)
+URI of the authentication portal (**default**: `/ssowat/`). This path **must** end with “`/`”.
 
 #### portal_port
 
-Web port of the authentication portal (**default**: `443`)
+Web port of the authentication portal (**default**: `443` for `https`, `80` for `http`)
 
 #### portal_scheme
 
@@ -86,7 +86,7 @@ Whether authentication should use secure connection or not (**default**: `https`
 
 #### domains
 
-List of handle domains (**default**: similar to `portal_domain`)
+List of handled domains (**default**: similar to `portal_domain`)
 
 #### ldap_host
 

--- a/config.lua
+++ b/config.lua
@@ -33,7 +33,7 @@ function get_config()
             -- Else just take the persistent rule's value
             else
                conf[k] = v
-        end
+            end
         end
     end
 
@@ -41,7 +41,7 @@ function get_config()
     -- Default configuration values
     default_conf = {
         portal_scheme             = "https",
-        portal_path               = "/ssowat",
+        portal_path               = "/ssowat/",
         local_portal_domain       = "yunohost.local",
         domains                   = { conf["portal_domain"], "yunohost.local" },
         session_timeout           = 60 * 60 * 24,     -- one day

--- a/config.lua
+++ b/config.lua
@@ -50,6 +50,8 @@ function get_config()
         ldap_host                 = "localhost",
         ldap_group                = "ou=users,dc=yunohost,dc=org",
         ldap_identifier           = "uid",
+        ldap_enforce_crypt        = true,
+        skipped_urls              = {},
         ldap_attributes           = {"uid", "givenname", "sn", "cn", "homedirectory", "mail", "maildrop"},
         allow_mail_authentication = true,
         default_language          = "en"

--- a/helpers.lua
+++ b/helpers.lua
@@ -293,7 +293,9 @@ function authenticate(user, password)
     -- cache shared table in order to eventually reuse it later when updating
     -- profile information or just passing credentials to an application.
     if connected then
-        ensure_user_password_uses_strong_hash(connected, user, password)
+        if conf['ldap_enforce_crypt'] then
+            ensure_user_password_uses_strong_hash(connected, user, password)
+        end
         cache:add(user.."-password", password, conf["session_timeout"])
         ngx.log(ngx.NOTICE, "Connected as: "..user)
         return user
@@ -575,12 +577,13 @@ end
 -- if it's not the case, it migrates the password to this new hash algorithm
 function ensure_user_password_uses_strong_hash(ldap, user, password)
     local current_hashed_password = nil
+    conf = config.get_config()
 
     for dn, attrs in ldap:search {
-        base = "ou=users,dc=yunohost,dc=org",
+        base = conf['ldap_group'],
         scope = "onelevel",
         sizelimit = 1,
-        filter = "(uid="..user..")",
+        filter = "("..conf['ldap_identifier'].."="..user..")",
         attrs = {"userPassword"}
     } do
         current_hashed_password = attrs["userPassword"]:sub(0, 10)


### PR DESCRIPTION
1º Let the admin choose if the passwords should be overwriten using crypt:

* new _optional_ conf parameter `ldap_enforce_crypt` with _default value_ `true` => *no regression* on existing setups
* only rehash the password using crypt if the above parameter is true.

2º Minor fixes

* In function `ensure_user_password_uses_strong_hash`, the LDAP parameters are used instead of being hard-coded.
* Set a default value to `skipped_urls` (=`{}`) so that the README can come back to its original state, ie. only `portal_domain` is mandatory.
