### PR TITLE
[fix] Fix the damn infinite redirection loop

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -391,6 +391,15 @@ end
 -- The default is to protect every URL by default.
 --
 
-hlp.flash("info", hlp.t("please_login"))
-local back_url = ngx.var.scheme .. "://" .. ngx.var.host .. ngx.var.uri .. hlp.uri_args_string()
+-- Only display this if HTTPS. For HTTP, we can't know if the user really is
+-- logged in or not, because the cookie is available only in HTTP...
+if ngx.var.scheme == "https" then
+    hlp.flash("info", hlp.t("please_login"))
+end
+
+-- Force the scheme to HTTPS. This is to avoid an issue with redirection loop
+-- when trying to access http://main.domain.tld/ (SSOwat finds that user aint
+-- logged in, therefore redirects to SSO, which redirects to the back_url, which
+-- redirect to SSO, ..)
+local back_url = "https://" .. ngx.var.host .. ngx.var.uri .. hlp.uri_args_string()
 return hlp.redirect(conf.portal_url.."?r="..ngx.encode_base64(back_url))


### PR DESCRIPTION
### Problem

See https://dev.yunohost.org/issues/856

After investigation, the issue typically happens when accessing `domain.tld` right after install : 
1. Access `domain.tld` (implicitly in HTTP)
2. SSOwat detects that you're not logged in yet and that there's no content available for non-authenticated users, therefore redirects to the SSO login page (with `http://domain.tld/` as return url)
3. Login... This sets a cookie to later prove to SSOwat that you're logged in.
4. Get redirected to the initial url, (`http://domain.tld/`)
5. Because it's HTTP, SSOwat cannot access the cookie and therefore cannot realize that user is logged in... Therefore go to step 2.

### Solution

I don't have an extensive knowledge of SSOwat, so my understanding is limited. But a simple and reasonable fix seems to force the scheme of the return URL to HTTPS.

### How to test

Access `http://domain.tld` on a clean install, log in, compare behavior with and without patch.