### PR TITLE
[enh] Add PCRE regex support

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -188,6 +188,8 @@ end
 -- If the URL matches one of the `redirected_urls` in the configuration file,
 -- just redirect to the target URL/URI
 --
+-- A match function to support PCRE and lua pattern
+-- lua pattern will be deprecated in YunoHost
 function match(s, regex)
     if rex.match(s, regex) or string.match(s,regex) then
         return true

--- a/access.lua
+++ b/access.lua
@@ -188,14 +188,14 @@ end
 -- If the URL matches one of the `redirected_urls` in the configuration file,
 -- just redirect to the target URL/URI
 --
--- A match function to support PCRE and lua pattern
--- lua pattern will be deprecated in YunoHost
+-- A match function that uses PCRE regex as default
+-- If '%.' is found in the regex, we assume it's a LUA regex (legacy code)
 function match(s, regex)
     if not string.find(regex, '%%%.') then
         if rex.match(s, regex) then
             return true
         end
-    elseif string.match(s,regex)  then
+    elseif string.match(s,regex) then
         return true
     end
     return false

--- a/access.lua
+++ b/access.lua
@@ -191,7 +191,11 @@ end
 -- A match function to support PCRE and lua pattern
 -- lua pattern will be deprecated in YunoHost
 function match(s, regex)
-    if rex.match(s, regex) or string.match(s,regex) then
+    if not string.find(regex, '%%%.') then
+        if rex.match(s, regex) then
+            return true
+        end
+    elseif string.match(s,regex)  then
         return true
     end
     return false

--- a/access.lua
+++ b/access.lua
@@ -22,6 +22,9 @@ local conf = config.get_config()
 -- Import helpers
 local hlp = require "helpers"
 
+-- Import Perl regular expressions library
+local rex = require "rex_pcre"
+
 -- Just a note for the client to know that he passed through the SSO
 ngx.header["X-SSO-WAT"] = "You've just been SSOed"
 
@@ -185,6 +188,12 @@ end
 -- If the URL matches one of the `redirected_urls` in the configuration file,
 -- just redirect to the target URL/URI
 --
+function match(s, regex)
+    if rex.match(s, regex) or string.match(s,regex) then
+        return true
+    end
+    return false
+end
 
 function detect_redirection(redirect_url)
     if hlp.string.starts(redirect_url, "http://")
@@ -209,9 +218,9 @@ end
 
 if conf["redirected_regex"] then
     for regex, redirect_url in pairs(conf["redirected_regex"]) do
-        if string.match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
-        or string.match(ngx.var.scheme.."://"..ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
-        or string.match(ngx.var.uri..hlp.uri_args_string(), regex) then
+        if match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
+        or match(ngx.var.scheme.."://"..ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
+        or match(ngx.var.uri..hlp.uri_args_string(), regex) then
             detect_redirection(redirect_url)
         end
     end
@@ -242,8 +251,8 @@ function is_protected()
         end
     end
     for _, regex in ipairs(conf["protected_regex"]) do
-        if string.match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
-        or string.match(ngx.var.uri..hlp.uri_args_string(), regex) then
+        if match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
+        or match(ngx.var.uri..hlp.uri_args_string(), regex) then
             return true
         end
     end
@@ -272,8 +281,8 @@ end
 
 if conf["skipped_regex"] then
     for _, regex in ipairs(conf["skipped_regex"]) do
-        if (string.match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
-        or  string.match(ngx.var.uri..hlp.uri_args_string(), regex))
+        if (match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
+        or  match(ngx.var.uri..hlp.uri_args_string(), regex))
         and not is_protected() then
             return hlp.pass()
         end
@@ -341,8 +350,8 @@ end
 
 if conf["unprotected_regex"] then
     for _, regex in ipairs(conf["unprotected_regex"]) do
-        if (string.match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
-        or  string.match(ngx.var.uri..hlp.uri_args_string(), regex))
+        if (match(ngx.var.host..ngx.var.uri..hlp.uri_args_string(), regex)
+        or  match(ngx.var.uri..hlp.uri_args_string(), regex))
         and not is_protected() then
             if hlp.is_logged_in() then
                 hlp.set_headers()


### PR DESCRIPTION
As the original branch of this https://github.com/YunoHost/SSOwat/pull/44 is missing, I have create a new one.

## The problem
Lua pattern are not well known and a lot of packager don't know how write this kind of regex. PCRE seems more familiar.

## Solution
Add support of PCRE, and keep support of lua pattern during a transition period.


## PR Status
Tested with nextcloud

## How to test
./ynh-dev use-git ssowat
setup one of this app and check it works as expected in their install script:
- kodi, 
- nextcloud (feature using /%.well%-known/)
- lutim as private
- lstu as private
- bozon as private,
- jirafeau
- lufi
## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 