### PR TITLE
[mod] Redirect after logout if `r` URI argument exists

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -889,8 +889,12 @@ function logout()
         flash("info", t("logged_out"))
     end
 
-    -- Redirect to portal anyway
-    return redirect(conf.portal_url)
+    -- Redirect with the `r` URI argument if it exists or redirect to portal
+    if args.r then
+        return redirect(ngx.decode_base64(args.r))
+    else
+        return redirect(conf.portal_url)
+    end
 end
 
 


### PR DESCRIPTION
### The problem
An app cannot ask for a logout without breaking UX: users end up on SSOwat login form, whereas going back to the app could be preferable in some cases.

### Solution
This PR addresses [YunoHost/issues#1201](https://github.com/YunoHost/issues/issues/1201).
The modification makes `logout()` helper test if `r` URI argument exists after logging out users. If so, the base64 address is decoded and nginx is tasked with the redirection.

### PR Status
Ready to be reviewed.

### Testing
Example: [Flarum package](https://github.com/YunoHost-Apps/flarum_ynh) is bundled with an SSOwat extension to support YNH users. It already puts an `r` argument while disconnecting YNH users and redirection has been successfully tested.

### Validation
- [ ] Principle agreement 0/2 :
- [ ] Quick review 0/1 :
- [ ] Simple test 0/1 :
- [ ] Deep review 0/1 : 