### PR TITLE
Add warning message about yunohost version being obsolete

### DIFF
--- a/portal/info.html
+++ b/portal/info.html
@@ -1,3 +1,5 @@
+<div class="wrapper messages warning">{{t_obsolete_version}}</div>
+
 <div class="ynh-wrapper user">
   <ul class="user-menu">
     <li><a class="icon icon-connexion" href="?action=logout">{{t_logout}}</a></li>

--- a/portal/locales/en.json
+++ b/portal/locales/en.json
@@ -19,6 +19,7 @@
    "confirm": "Confirm",
    "login": "Login",
    "logout": "Logout",
+   "obsolete_version": "The version of YunoHost running on this server is obsolete and should be upgraded to YunoHost 3.x / Stretch. Please contact your administrator about this.",
    "password_changed": "Password successfully changed",
    "password_changed_error": "An error occurred on password changing",
    "password_not_match": "New passwords don't match",


### PR DESCRIPTION
### Problem

Same as https://github.com/YunoHost/yunohost-admin/pull/219 : Some admins might still be on Jessie and might have not seen the migration about Stretch (e.g. if they don't follow the announcements on the forum). We need to encourage them to switch to Stretch because Jessie is more and more obsolete.

### Solution

This is an additional change in the SSO page to be displayed to logged-in users at the top of the page, in case the administrator does not often connect to the webadmin. 

N.B : this is to be merged and release in jessie.