### PR TITLE
Fix string helper if string is empty

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -38,7 +38,10 @@ end
 
 -- Test whether a string starts with another
 function string.starts(String, Start)
-   return string.sub(String, 1, string.len(Start)) == Start
+    if not String then
+        return false
+    end
+    return string.sub(String, 1, string.len(Start)) == Start
 end
 
 


### PR DESCRIPTION
# Problem

I saw sometime some bug while some boot try some `POST` request

```
DATE HOUR [error] 4844#4844: *39358 lua entry thread aborted: runtime error: /usr/share/ssowat/helpers.lua:41: bad argument #1 to 'sub' (string expected, got nil)
stack traceback:
coroutine 0:
        [C]: in function 'sub'
        /usr/share/ssowat/helpers.lua:41: in function 'starts'
        /usr/share/ssowat/access.lua:165: in function </usr/share/ssowat/access.lua:1>, client: 148.72.232.64, server: domain.tld, request: "POST /yunohost/sso/?r=AWFf8fal3FAwfd3ASF3f9afafaFA=/xmlrpc.php HTTP/1.1", host: "domain.tld"
```

# Solution

Return `false` if the helper get a null string as input.

# PR status

Not tested because I don't know how to reproduce the bug.