### PR TITLE
Theming reloaded smallfixes

### DIFF
--- a/portal/assets/css/ynh_portal.css
+++ b/portal/assets/css/ynh_portal.css
@@ -82,6 +82,9 @@ body {
   margin: 0;
   padding: 0;
   height: 100%;
+  top: 0;
+  position: absolute;
+  width: 100%;
 }
 
 h1:first-child,
@@ -121,6 +124,12 @@ img {
 /* Layout */
 .content {
   padding: 2%;
+}
+
+.logged .content {
+  width: 100%;
+  height: 100%;
+  overflow: auto; /* scroll .content, not body for easier background customization */
 }
 
 .ynh-wrapper {

--- a/portal/assets/themes/clouds/custom_portal.css
+++ b/portal/assets/themes/clouds/custom_portal.css
@@ -16,12 +16,6 @@ a.app-tile,
   color: black !important;
 }
 
-.content {
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-}
-
 .ynh-user-portal {
   background-image: url("background.jpg");
   background-repeat: no-repeat;

--- a/portal/assets/themes/clouds/custom_portal.css
+++ b/portal/assets/themes/clouds/custom_portal.css
@@ -16,6 +16,12 @@ a.app-tile,
   color: black !important;
 }
 
+.content {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
 .ynh-user-portal {
   background-image: url("background.jpg");
   background-repeat: no-repeat;


### PR DESCRIPTION
In portal, scroll .content, not body (otherwise if a custom background image is set the background is also scrolling).
I made it global, not only in clouds theme, because it makes customization more straightforward.
Also had to change a bit the css rules for body, otherwise it fucks the login page.