### PR TITLE
Theming reloaded redirections improved

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -162,7 +162,12 @@ then
         -- If all the previous cases have failed, redirect to portal
         else
             hlp.flash("info", hlp.t("please_login"))
-            return hlp.redirect(conf.portal_url)
+            -- Force the scheme to HTTPS. This is to avoid an issue with redirection loop
+            -- when trying to access http://main.domain.tld/ (SSOwat finds that user aint
+            -- logged in, therefore redirects to SSO, which redirects to the back_url, which
+            -- redirect to SSO, ..)
+            local back_url = "https://" .. ngx.var.host .. ngx.var.uri .. hlp.uri_args_string()
+            return hlp.redirect(conf.portal_url.."?r="..ngx.encode_base64(back_url))
         end
 
 

--- a/portal/assets/themes/clouds/custom_portal.css
+++ b/portal/assets/themes/clouds/custom_portal.css
@@ -16,12 +16,6 @@ a.app-tile,
   color: black !important;
 }
 
-.content {
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-}
-
 .ynh-user-portal {
   background-image: url("background.jpg");
   background-repeat: no-repeat;

--- a/portal/assets/themes/clouds/custom_portal.css
+++ b/portal/assets/themes/clouds/custom_portal.css
@@ -16,6 +16,12 @@ a.app-tile,
   color: black !important;
 }
 
+.content {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
 .ynh-user-portal {
   background-image: url("background.jpg");
   background-repeat: no-repeat;


### PR DESCRIPTION
With this commit, if you query /yunohost/sso/edit.html page when you're logged out, it will redirect you to login page, then if you login successfully redirect you to the edit page.