### PR TITLE
Fixed: bug serving files because of LUA exception

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -317,10 +317,8 @@ end
 --
 
 function scandir(directory, callback)
-    -- FIXME : this sometime fails (randomly...)
-    -- because of 'interrupted system call'
     -- use find (and not ls) to list only files recursively and with their full path relative to the asked directory
-    local pfile = io.popen('cd "'..directory..'" && find * -type f')
+    local pfile = io.popen('find "'..directory..'" -type f')
     for filename in pfile:lines() do
         callback(filename)
     end


### PR DESCRIPTION
"Interrupted system call" during PWDIR change on "popen" function
Restored by removing FIND's wildcard which could yield fo emptiness
(example : `mydir/` is empty; making `cd mydir && find *` yielding
to non argumented FIND function.

Tested on Stretch with nginx (1.10.3-1+deb9u2) and lua5.1 (5.1.5-8.1+b2).

Note that this could lead to bugs, code refactor should enclose lua-filesystem (1.6.3-1),
but I'm a rookie in LUA.