### PR TITLE
Logging reloaded

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -372,6 +372,11 @@ if auth_header then
     _, _, user, password = string.find(ngx.decode_base64(b64_cred), "^(.+):(.+)$")
     user = hlp.authenticate(user, password)
     if user then
+        -- If user has no access to this URL, redirect him to the portal
+        if not hlp.has_access(user) then
+           return hlp.redirect(conf.portal_url)
+        end
+
         hlp.set_headers(user)
 
         -- If user has no access to this URL, redirect him to the portal

--- a/config.lua
+++ b/config.lua
@@ -55,7 +55,8 @@ function get_config()
         ldap_attributes           = {"uid", "givenname", "sn", "cn", "homedirectory", "mail", "maildrop"},
         allow_mail_authentication = true,
         default_language          = "en",
-        theme                     = "default"
+        theme                     = "default",
+        logging                   = "fatal" -- Only log fatal messages by default (so apriori nothing)
     }
 
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -117,7 +117,7 @@ function set_auth_cookie(user, domain)
         cache:add("session_"..user, session_key, conf["session_max_timeout"])
     end
     local hash = ngx.md5(srvkey..
---               "|" ..ngx.var.remote_addr..
+               "|" ..ngx.var.remote_addr..
                "|"..user..
                "|"..expire..
                "|"..session_key)
@@ -187,11 +187,11 @@ function is_logged_in()
                 if cache:get(user.."-password") then
                     authUser = user
                     local hash = ngx.md5(srvkey..
---                            "|"..ngx.var.remote_addr..
+                            "|"..ngx.var.remote_addr..
                             "|"..authUser..
                             "|"..expireTime..
                             "|"..session_key)
-		    if hash ~= authHash then
+                    if hash ~= authHash then
                         log("Hash "..authHash.." rejected for "..user.."@"..ngx.var.remote_addr)
                     end
                     return hash == authHash

--- a/helpers.lua
+++ b/helpers.lua
@@ -12,10 +12,6 @@ local conf = config.get_config()
 local logger = require("log")
 logger.outfile = "/var/log/nginx/ssowat.log"
 
-function log(...)
-    logger.info(...)
-end
-
 -- Read a FS stored file
 function read_file(file)
     local f = io.open(file, "rb")
@@ -164,7 +160,7 @@ function set_auth_cookie(user, domain)
         "SSOwAuthHash="..hash..cookie_str,
         "SSOwAuthExpire="..expire..cookie_str
     }
-    log("Hash "..hash.." generated for "..user.."@"..ngx.var.remote_addr)
+    logger.info("Hash "..hash.." generated for "..user.."@"..ngx.var.remote_addr)
 end
 
 
@@ -228,7 +224,7 @@ function is_logged_in()
                             "|"..expireTime..
                             "|"..session_key)
                     if hash ~= authHash then
-                        log("Hash "..authHash.." rejected for "..user.."@"..ngx.var.remote_addr)
+                        logger.info("Hash "..authHash.." rejected for "..user.."@"..ngx.var.remote_addr)
                     end
                     return hash == authHash
                 end

--- a/helpers.lua
+++ b/helpers.lua
@@ -9,6 +9,12 @@ module('helpers', package.seeall)
 
 local cache = ngx.shared.cache
 local conf = config.get_config()
+local logger = require("log")
+logger.outfile = "/var/log/nginx/ssowat.log"
+
+function log(...)
+    logger.info(...)
+end
 
 -- Read a FS stored file
 function read_file(file)
@@ -111,7 +117,7 @@ function set_auth_cookie(user, domain)
         cache:add("session_"..user, session_key, conf["session_max_timeout"])
     end
     local hash = ngx.md5(srvkey..
-               "|" ..ngx.var.remote_addr..
+--               "|" ..ngx.var.remote_addr..
                "|"..user..
                "|"..expire..
                "|"..session_key)
@@ -125,6 +131,7 @@ function set_auth_cookie(user, domain)
         "SSOwAuthHash="..hash..cookie_str,
         "SSOwAuthExpire="..expire..cookie_str
     }
+    log("Hash "..hash.." generated for "..user.."@"..ngx.var.remote_addr)
 end
 
 
@@ -180,10 +187,13 @@ function is_logged_in()
                 if cache:get(user.."-password") then
                     authUser = user
                     local hash = ngx.md5(srvkey..
-                            "|"..ngx.var.remote_addr..
+--                            "|"..ngx.var.remote_addr..
                             "|"..authUser..
                             "|"..expireTime..
                             "|"..session_key)
+		    if hash ~= authHash then
+                        log("Hash "..authHash.." rejected for "..user.."@"..ngx.var.remote_addr)
+                    end
                     return hash == authHash
                 end
             end
@@ -191,6 +201,15 @@ function is_logged_in()
     end
 
     return false
+end
+
+function log_access(user, app)
+  local key = "ACC|"..user.."|"..app
+  local block = cache:get(key)
+  if block == nil then
+    logger.info("ACC "..app.." by "..user.."@"..ngx.var.remote_addr)
+    cache:set(key, "block", 60)
+  end
 end
 
 
@@ -211,7 +230,7 @@ function has_access(user, url)
     end
 
     -- Loop through user's ACLs and return if the URL is authorized.
-    for u, _ in pairs(conf["users"][user]) do
+    for u, app in pairs(conf["users"][user]) do
 
         -- Replace the original domain by a local one if you are connected from
         -- a non-global domain name.
@@ -219,7 +238,10 @@ function has_access(user, url)
             u = string.gsub(u, conf["original_portal_domain"], conf["local_portal_domain"])
         end
 
-        if string.starts(url, string.sub(u, 1, -2)) then return true end
+        if string.starts(url, string.sub(u, 1, -2)) then
+            log_access(user, app)
+            return true
+        end
     end
     return false
 end
@@ -268,11 +290,13 @@ function authenticate(user, password)
     if connected then
         cache:add(user.."-password", password, conf["session_timeout"])
         ngx.log(ngx.NOTICE, "Connected as: "..user)
+        logger.info("AUTHSUCC "..user.."@"..ngx.var.remote_addr)
         return user
 
     -- Else, the username/email or the password is wrong
     else
         ngx.log(ngx.ERR, "Connection failed for: "..user)
+        logger.info("AUTHFAIL "..user.."@"..ngx.var.remote_addr)
         return false
     end
 end

--- a/init.lua
+++ b/init.lua
@@ -8,6 +8,10 @@
 -- another.
 --
 
+-- Path of the configuration
+conf_path = "/etc/ssowat/conf.json"
+log_file = "/var/log/nginx/ssowat.log"
+
 -- Remove prepending '@' & trailing 'init.lua'
 script_path = string.sub(debug.getinfo(1).source, 2, -9)
 
@@ -22,6 +26,11 @@ local lfs = require "lfs"
 local socket = require "socket"
 local config = require "config"
 lustache = require "lustache"
+
+-- Make sure the log file exists and we can write in it
+io.popen("touch "..log_file)
+io.popen("chown www-data "..log_file)
+io.popen("chmod u+w "..log_file)
 
 -- Persistent shared table
 flashs = {}
@@ -53,9 +62,6 @@ for file in lfs.dir(locale_dir) do
         i18n[lang] = json.decode(locale_file:read("*all"))
     end
 end 
-
--- Path of the configuration
-conf_path = "/etc/ssowat/conf.json"
 
 -- You should see that in your Nginx error logs by default
 ngx.log(ngx.INFO, "SSOwat ready")

--- a/log.lua
+++ b/log.lua
@@ -8,11 +8,10 @@
 --
 
 local log = { _version = "0.1.0" }
+local conf = config.get_config()
 
 log.usecolor = true
-log.outfile = nil
-log.level = "trace"
-
+log.level = conf.logging
 
 local modes = {
   { name = "trace", color = "\27[34m", },
@@ -55,7 +54,7 @@ end
 for i, x in ipairs(modes) do
   local nameupper = x.name:upper()
   log[x.name] = function(...)
-    
+
     -- Return early if we're below the log level
     if i < levels[log.level] then
       return
@@ -63,27 +62,21 @@ for i, x in ipairs(modes) do
 
     local msg = tostring(...)
     local info = debug.getinfo(2, "Sl")
---    local lineinfo = info.short_src .. ":" .. info.currentline
-    local lineinfo = ""
 
     -- Output to console
-    print(string.format("%s[%-6s%s]%s %s: %s",
+    print(string.format("%s[%-6s%s]%s %s",
                         log.usecolor and x.color or "",
                         nameupper,
                         os.date("%H:%M:%S"),
                         log.usecolor and "\27[0m" or "",
-                        lineinfo,
                         msg))
 
     -- Output to log file
-    if log.outfile then
-      local fp = io.open(log.outfile, "a")
-      local str = string.format("[%-6s%s] %s: %s\n",
-                                nameupper, os.date(), lineinfo, msg)
-      fp:write(str)
-      fp:close()
-    end
-
+    local fp = io.open(log_file, "a")
+    local str = string.format("[%-6s%s] %s\n",
+                            nameupper, os.date(), msg)
+    fp:write(str)
+    fp:close()
   end
 end
 

--- a/log.lua
+++ b/log.lua
@@ -1,0 +1,91 @@
+--
+-- log.lua
+--
+-- Copyright (c) 2016 rxi
+--
+-- This library is free software; you can redistribute it and/or modify it
+-- under the terms of the MIT license. See LICENSE for details.
+--
+
+local log = { _version = "0.1.0" }
+
+log.usecolor = true
+log.outfile = nil
+log.level = "trace"
+
+
+local modes = {
+  { name = "trace", color = "\27[34m", },
+  { name = "debug", color = "\27[36m", },
+  { name = "info",  color = "\27[32m", },
+  { name = "warn",  color = "\27[33m", },
+  { name = "error", color = "\27[31m", },
+  { name = "fatal", color = "\27[35m", },
+}
+
+
+local levels = {}
+for i, v in ipairs(modes) do
+  levels[v.name] = i
+end
+
+
+local round = function(x, increment)
+  increment = increment or 1
+  x = x / increment
+  return (x > 0 and math.floor(x + .5) or math.ceil(x - .5)) * increment
+end
+
+
+local _tostring = tostring
+
+local tostring = function(...)
+  local t = {}
+  for i = 1, select('#', ...) do
+    local x = select(i, ...)
+    if type(x) == "number" then
+      x = round(x, .01)
+    end
+    t[#t + 1] = _tostring(x)
+  end
+  return table.concat(t, " ")
+end
+
+
+for i, x in ipairs(modes) do
+  local nameupper = x.name:upper()
+  log[x.name] = function(...)
+    
+    -- Return early if we're below the log level
+    if i < levels[log.level] then
+      return
+    end
+
+    local msg = tostring(...)
+    local info = debug.getinfo(2, "Sl")
+--    local lineinfo = info.short_src .. ":" .. info.currentline
+    local lineinfo = ""
+
+    -- Output to console
+    print(string.format("%s[%-6s%s]%s %s: %s",
+                        log.usecolor and x.color or "",
+                        nameupper,
+                        os.date("%H:%M:%S"),
+                        log.usecolor and "\27[0m" or "",
+                        lineinfo,
+                        msg))
+
+    -- Output to log file
+    if log.outfile then
+      local fp = io.open(log.outfile, "a")
+      local str = string.format("[%-6s%s] %s: %s\n",
+                                nameupper, os.date(), lineinfo, msg)
+      fp:write(str)
+      fp:close()
+    end
+
+  end
+end
+
+
+return log


### PR DESCRIPTION
Working on finishing https://github.com/YunoHost/yunohost/pull/797 where we need to rework part of the logic of protected/unprotected url ... Thought I would need some sort of straightforward mechanism to get logs from inside SSOwat's Lua code, so ended up resurrecting https://github.com/YunoHost/SSOwat/pull/78 ...

So with this PR, SSOwat logs debug messages in `/var/log/nginx/ssowat.log`, though nothing will be logged by default and if you actually want to enable it you need to add `logging = "debug"` to ssowat's configuration. (We probably don't want to enable all that logging by default because that's way too much information and there's also metadata / privacy consideration)