### PR TITLE
More extensive check between allowed rules vs. protected rules

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -208,17 +208,15 @@ end
 -- If the URL matches one of the `redirected_urls` in the configuration file,
 -- just redirect to the target URL/URI
 --
--- A match function that uses PCRE regex as default
+-- The 'match' function uses PCRE regex as default
 -- If '%.' is found in the regex, we assume it's a LUA regex (legacy code)
+-- 'match' returns the matched text.
 function match(s, regex)
     if not string.find(regex, '%%%.') then
-        if rex.match(s, regex) then
-            return true
-        end
-    elseif string.match(s,regex) then
-        return true
+        return rex.match(s, regex)
+    else
+        return string.match(s,regex)
     end
-    return false
 end
 
 function detect_redirection(redirect_url)
@@ -290,7 +288,6 @@ function is_protected()
     logger.debug(ngx.var.uri.." is not in protected_urls/regex")
     return false
 end
-
 
 --
 -- 5. Skipped URLs

--- a/helpers.lua
+++ b/helpers.lua
@@ -293,7 +293,10 @@ function has_access(user)
     logger.debug("Longest allowed match : "..longest_allowed_match)
     logger.debug("Longest protected match : "..longest_protected_match)
 
-    if string.len(longest_allowed_match) >= string.len(longest_protected_match) then
+    -- For the user to be able to access the content, at least one rule should
+    -- exist and it should be the longest match
+    if longest_allowed_match ~= ""
+    and string.len(longest_allowed_match) >= string.len(longest_protected_match) then
         logger.debug("Logged-in user can access "..ngx.var.uri)
         log_access(user, longest_allowed_match)
         return true


### PR DESCRIPTION
This is a follow-up of [this discussion](https://github.com/YunoHost/yunohost/pull/797#issuecomment-533684426) to try to fix this thing where if you have these settings : 

```
    "protected_urls": [
        "yolo.test/foo", 
        "yolo.test/foo/admin"
    ], 
    "users": {
        "alice": {
            "yolo.test/foo": "Foo Test", 
            "yolo.test/foo/admin": "Foo Test (Admin)"
        }, 
        "bob": {
            "yolo.test/foo": "Foo Test"
        }
    }
```

then currently `bob` has access to `/foo/admin` despite the fact that the intention would be that only `alice` should ...

This draft allow to perform a more extensive check, and by this I mean checking what's the rule that has the longest match with respect to the requested uri...

This seem to be kinda working but gotta run moar test to validate the thousand of different use case to see that this does not cause any regression