### PR TITLE
[fix] CVE-2019-11043

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -30,7 +30,6 @@ ngx.header["X-SSO-WAT"] = "You've just been SSOed"
 
 -- Quick fix for CVE-2019-11043 about php-fpm and nginx
 local loweruri = string.lower(ngx.var.uri)
-ngx.header["X-SSO-DEBUG"] = loweruri
 if string.match(loweruri, "\n") or string.match(loweruri, "\r") then
     return ngx.exit(ngx.HTTP_FORBIDDEN)
 end

--- a/access.lua
+++ b/access.lua
@@ -28,6 +28,13 @@ local rex = require "rex_pcre"
 -- Just a note for the client to know that he passed through the SSO
 ngx.header["X-SSO-WAT"] = "You've just been SSOed"
 
+-- Quick fix for CVE-2019-11043 about php-fpm and nginx
+local loweruri = string.lower(ngx.var.uri)
+ngx.header["X-SSO-DEBUG"] = loweruri
+if string.match(loweruri, "\n") or string.match(loweruri, "\r") then
+    return ngx.exit(ngx.HTTP_FORBIDDEN)
+end
+
 
 --
 -- 1. LOGIN


### PR DESCRIPTION
I suggest this to fix CVE-2019-11043 .

Note: it's a theorical fix, i think it should fix the exloit but for instance i hadn't tested it...

I have just tested that

```
curl -i -X GET --url http:/DOMAIN/%0d
curl -i -X GET --url http://DOMAIN/%0a
```
return FORBIDEN