### PR TITLE
Fix legacy/new permissions

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -267,16 +267,17 @@ end
 function has_access(user)
     user = user or authUser
 
+    logger.debug("User "..user.." try to access "..ngx.var.uri)
+    
     -- Get the longest url permission
     longest_permission_match = longest_url_path(permission_matches()) or ""
 
     logger.debug("Longest permission match : "..longest_permission_match)
 
-    -- If no permission matches, it means that there is no
-    -- permission defined for this url, a logged-in user can access it.
+    -- If no permission matches, it means that there is no permission defined for this url.
     if longest_permission_match == "" then
-        logger.debug("No access rules defined for user "..user..", assuming it can access.")
-        return true
+        logger.debug("No access rules defined for user "..user..", assuming it cannot access.")
+        return false
     end
 
     -- All user in this permission


### PR DESCRIPTION
Needs this [PR](https://github.com/YunoHost/yunohost/pull/871)

Close: https://github.com/YunoHost/SSOwat/pull/152
Resolve: https://github.com/YunoHost/issues/issues/1507
And should resolve all our problems with legacy/new permissions system

I've tested it myself, but someone familiar with this project should indeed do a double triple check


To test it, apply https://github.com/YunoHost/yunohost/pull/871 and this PR, reload nginx (`systemctl reload nginx`) and run `yunohost app ssowatconf`
Finally, play with unprotected/protected/skipped_url