### PR TITLE
Refactor skipped/protected/unprotecter

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -256,7 +256,8 @@ logger.debug("longest protected "..longest_protected_match)
 --
 
 if longest_skipped_match ~= ""
-and string.len(longest_skipped_match) >= string.len(longest_protected_match) then
+and string.len(longest_skipped_match) >= string.len(longest_protected_match) 
+and string.len(longest_skipped_match) > string.len(longest_unprotected_match) then
     logger.debug("Skipping "..ngx.var.uri)
     return hlp.pass()
 end

--- a/helpers.lua
+++ b/helpers.lua
@@ -267,16 +267,17 @@ end
 function has_access(user)
     user = user or authUser
 
+    logger.debug("User "..user.." try to access "..ngx.var.uri)
+    
     -- Get the longest url permission
     longest_permission_match = longest_url_path(permission_matches()) or ""
 
     logger.debug("Longest permission match : "..longest_permission_match)
 
-    -- If no permission matches, it means that there is no
-    -- permission defined for this url, a logged-in user can access it.
+    -- If no permission matches, it means that there is no permission defined for this url.
     if longest_permission_match == "" then
-        logger.debug("No access rules defined for user "..user..", assuming it can access.")
-        return true
+        logger.debug("No access rules defined for user "..user..", assuming it cannot access.")
+        return false
     end
 
     -- All user in this permission

--- a/helpers.lua
+++ b/helpers.lua
@@ -306,8 +306,7 @@ function permission_matches()
     local url_matches = {}
 
     for url, permission in pairs(conf["permissions"]) do
-        if string.starts(ngx.var.host..ngx.var.uri..uri_args_string(), url)
-        or string.starts(ngx.var.uri..uri_args_string(), url) then
+        if string.starts(ngx.var.host..ngx.var.uri..uri_args_string(), url) then
             logger.debug("Url permission match current uri : "..url)
 
             table.insert(url_matches, url)

--- a/helpers.lua
+++ b/helpers.lua
@@ -262,7 +262,7 @@ function log_access(user, uri)
 end
 
 
--- Check whether a user is allowed to access a URL using the `users` directive
+-- Check whether a user is allowed to access a URL using the `permissions` directive
 -- of the configuration file
 function has_access(user)
     user = user or authUser

--- a/helpers.lua
+++ b/helpers.lua
@@ -317,6 +317,39 @@ function permission_matches()
     return url_matches
 end
 
+function get_matches(section)
+    if not conf[section.."_urls"] then
+        conf[section.."_urls"] = {}
+    end
+    if not conf[section.."_regex"] then
+        conf[section.."_regex"] = {}
+    end
+
+    local url_matches = {}
+
+    for _, url in ipairs(conf[section.."_urls"]) do
+        if string.starts(ngx.var.host..ngx.var.uri..uri_args_string(), url)
+        or string.starts(ngx.var.uri..uri_args_string(), url) then
+            logger.debug(section.."_url match current uri : "..url)
+            table.insert(url_matches, url)
+        end
+    end
+    for _, regex in ipairs(conf[section.."_regex"]) do
+        local m1 = match(ngx.var.host..ngx.var.uri..uri_args_string(), regex)
+        local m2 = match(ngx.var.uri..uri_args_string(), regex)
+        if m1 then
+            logger.debug(section.."_regex match current uri : "..regex.." with "..m1)
+            table.insert(url_matches, m1)
+        end
+        if m2 then
+            logger.debug(section.."_regex match current uri : "..regex.." with "..m2)
+            table.insert(url_matches, m2)
+        end
+    end
+
+    return url_matches
+end
+
 function longest_url_path(urls)
     local longest = nil
     for _, url in ipairs(urls) do
@@ -328,6 +361,9 @@ function longest_url_path(urls)
         if not longest or string.len(longest) < string.len(current) then
             longest = current
         end
+    end
+    if longest and string.ends(longest, "/") then
+        longest = string.sub(longest, 1, -2)
     end
     return longest
 end


### PR DESCRIPTION
Replace #153
Related: #149 and YunoHost-Apps/ttrss_ynh/issues/70

The idea is to get the longest protected/unprotected/skipped_url/regex, and to keep only the longest one among them

(the code to review is only the latest commit af89299)