### PR TITLE
Don't set header if user don't have access

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -318,7 +318,7 @@ end
 
 if longest_unprotected_match ~= ""
 and string.len(longest_unprotected_match) > string.len(longest_protected_match) then
-    if hlp.is_logged_in() then
+    if hlp.is_logged_in() and hlp.has_access() then
         serveYnhpanel()
 
         hlp.set_headers()

--- a/access.lua
+++ b/access.lua
@@ -318,10 +318,11 @@ end
 
 if longest_unprotected_match ~= ""
 and string.len(longest_unprotected_match) > string.len(longest_protected_match) then
-    if hlp.is_logged_in() and hlp.has_access() then
+    if hlp.is_logged_in() then
         serveYnhpanel()
-
-        hlp.set_headers()
+        if hlp.has_access() then
+            hlp.set_headers()
+        end
     end
     logger.debug(ngx.var.uri.." is in unprotected_urls")
     return hlp.pass()


### PR DESCRIPTION
# Problem

In `unprotected_uris` case a user logged in which has no access to the application shouldn't have the authentication header.

# Status

Tested quickly and it work on my side.