### PR TITLE
[fix] invalid more cookies

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -214,7 +214,7 @@ function delete_redirect_cookie()
                        "; Expires="..expired_time..
                        "; Secure"..
                        "; HttpOnly"..
-                       "; SameSite=Lax ;;"
+                       "; SameSite=Lax"
     ngx.header["Set-Cookie"] = "SSOwAuthRedirect=;" ..cookie_str
 end
 


### PR DESCRIPTION
According to roy on xmpp this fix help clearing more cookies (maybe not all) properly.

I don't understand why but I didn't wanted to lose that information.