### PR TITLE
remove absolute path

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -297,10 +297,7 @@ function serveYnhpanel()
     serveAsset("/ynh_portal.js", "js/ynh_portal.js")
     serveAsset("/ynh_overlay.css", "css/ynh_overlay.css")
     -- serve theme's files
-    -- FIXME? I think it would be better here not to use an absolute path
-    -- but I didn't succeed to figure out where is the current location of the script
-    -- if you call it from "portal/assets/themes/" the ls fails
-    scandir("/usr/share/ssowat/portal/assets/themes/"..conf.theme, serveThemeFile)
+    scandir("themes/"..conf.theme, serveThemeFile)
 end
 
 --


### PR DESCRIPTION
Remove the fix me about absolute path

We already use relative path here:
https://github.com/YunoHost/SSOwat/blob/8cb62d5a591f3d5b2b2def57688775cea9de11f5/access.lua#L290
https://github.com/YunoHost/SSOwat/blob/8cb62d5a591f3d5b2b2def57688775cea9de11f5/access.lua#L297-L298