### PR TITLE
fix theme loading

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -272,7 +272,7 @@ end
 
 function scandir(directory, callback)
     -- use find (and not ls) to list only files recursively and with their full path relative to the asked directory
-    local pfile = io.popen('find "'..directory..'" -type f')
+    local pfile = io.popen('find "'..directory..'" -type f -printf \"%f\n\"')
     for filename in pfile:lines() do
         callback(filename)
     end


### PR DESCRIPTION
Fix https://github.com/YunoHost/issues/issues/1562

The command `find /dir -type f` returns a list of absolute path of files.
For example for the theme `clouds`, we get: 
```
$ find /usr/share/ssowat/portal/assets/themes/clouds/ -type f
/usr/share/ssowat/portal/assets/themes/clouds/custom_portal.css
/usr/share/ssowat/portal/assets/themes/clouds/custom_overlay.css
/usr/share/ssowat/portal/assets/themes/clouds/background.jpg
/usr/share/ssowat/portal/assets/themes/clouds/custom_portal.js
/usr/share/ssowat/portal/assets/themes/clouds/cloud.png
```
The [callback](https://github.com/YunoHost/SSOwat/blob/20de3f5f37aa29847c97375cf69f89c188463ce0/access.lua#L277) checks [if the uri matches with `/ynhtheme/the_absolute_path_of_the_file`](https://github.com/YunoHost/SSOwat/blob/20de3f5f37aa29847c97375cf69f89c188463ce0/access.lua#L283), which is never true because we just want to check the filename.

To solve the problem, make sure that "find" only returns filenames.

