### PR TITLE
Allow the user's password manager to automatically enter the password/username/new-password

### DIFF
--- a/portal/login.html
+++ b/portal/login.html
@@ -2,11 +2,11 @@
 <form class="login-form" name="input" action="" method="post">
   <div class="form-group">
     <label class="icon icon-user" for="user"><span class="element-invisible">{{t_username}}</span></label>
-    <input id="user" type="text" name="user" placeholder="{{t_username}}" class="form-text" autofocus required>
+    <input id="user" type="text" name="user" placeholder="{{t_username}}" class="form-text" autocomplete="username" autofocus required>
   </div>
   <div class="form-group">
     <label class="icon icon-lock" for="password"><span class="element-invisible">{{t_password}}</span></label>
-    <input id="password" type="password" name="password" placeholder="{{t_password}}" class="form-text" required>
+    <input id="password" type="password" name="password" placeholder="{{t_password}}" class="form-text" autocomplete="current-password" required>
   </div>
   <input type="submit" value="{{t_login}}" class="btn classic-btn large-btn">
 </form>

--- a/portal/password.html
+++ b/portal/password.html
@@ -20,14 +20,14 @@
     <div class="form-section">
       <div class="form-group">
         <label for="currentpassword">{{t_current_password}}</label>
-        <input type="password" class="form-text" id="currentpassword" name="currentpassword" placeholder="•••••" required>
+        <input type="password" class="form-text" id="currentpassword" name="currentpassword" placeholder="•••••" autocomplete="current-password" required>
       </div>
     </div>
     <div class="form-section">
       <div class="form-group">
         <label for="newpassword">{{t_new_password}}</label>
-        <input type="password" class="form-text" id="newpassword" name="newpassword" placeholder="•••••" required>
-        <input type="password" class="form-text" id="confirm" name="confirm" placeholder="{{t_confirm}}" required>
+        <input type="password" class="form-text" id="newpassword" name="newpassword" placeholder="•••••" autocomplete="new-password" required>
+        <input type="password" class="form-text" id="confirm" name="confirm" placeholder="{{t_confirm}}" autocomplete="new-password" required>
       </div>
       <div class="btn-group">
         <a role="button" href="portal.html" class="btn large-btn btn-default">{{t_cancel}}</a>


### PR DESCRIPTION
Allow the user's password manager to automatically enter the password/username/new-password

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete