### PR TITLE
Reload the conf only if files has been modified

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -6,14 +6,40 @@
 
 module('config', package.seeall)
 
+local config_attributes = nil
+local config_persistent_attributes = nil
+
+local conf = {}
+
+function compare_attributes(file_attributes1, file_attributes2)
+    if file_attributes1 == nil and file_attributes2 == nil then
+        return true
+    elseif file_attributes1 == nil and file_attributes2 ~= nil or file_attributes1 ~= nil and file_attributes2 == nil then
+        return false
+    end
+    return file_attributes1["modification"] == file_attributes2["modification"] and file_attributes1["size"] == file_attributes2["size"]
+end
+
 function get_config()
 
-    -- Load the configuration file
-    local conf_file = assert(io.open(conf_path, "r"), "Configuration file is missing")
-    local conf = json.decode(conf_file:read("*all"))
-    if conf_file ~= nil then
-        conf_file:close()
+    -- Get config files attributes (timestamp modification and size)
+    local new_config_attributes = lfs.attributes(conf_path, {"modification", "size"})
+    local new_config_persistent_attributes = lfs.attributes(conf_path..".persistent", {"modification", "size"})
+
+    if compare_attributes(new_config_attributes, config_attributes) and compare_attributes(new_config_persistent_attributes, config_persistent_attributes) then
+        return conf
+    -- If the file is being written, its size may be 0 and reloading fails, return the last valid config
+    elseif new_config_attributes == nil or new_config_attributes["size"] == 0 then
+        return conf
     end
+
+    -- If the timestamp of the modification or the size is different, reload the configuration.
+    config_attributes = new_config_attributes
+    config_persistent_attributes = new_config_persistent_attributes
+    
+    local conf_file = assert(io.open(conf_path, "r"), "Configuration file is missing")
+    conf = json.decode(conf_file:read("*all"))
+    conf_file:close()
 
     -- Load additional rules from the `.persistent` configuration file.
     -- The `.persistent` file contains rules that will overwrite previous rules.
@@ -24,19 +50,19 @@ function get_config()
         persistent_conf_file:close()
         for k, v in pairs(perm_conf) do
 
-           -- If the configuration key already exists and is a table, merge it
-           if conf[k] and type(v) == "table" then
-               for subk, subv in pairs(v) do
-                   if type(subk) == "number" then
-                       table.insert(conf[k], subv)
-                   else
-                       conf[k][subk] = subv
-                   end
-               end
+            -- If the configuration key already exists and is a table, merge it
+            if conf[k] and type(v) == "table" then
+                for subk, subv in pairs(v) do
+                    if type(subk) == "number" then
+                        table.insert(conf[k], subv)
+                    else
+                        conf[k][subk] = subv
+                    end
+                end
 
             -- Else just take the persistent rule's value
             else
-               conf[k] = v
+                conf[k] = v
             end
         end
     end


### PR DESCRIPTION
The idea is to avoid read and reconstruct all the config on each request.

I tested several case:

- Change the config file
- Change the persistent config file
- Remove the persistent config file
- Create a persistent config file

With this code:

```lua
local json = require"json"
local lfs = require"lfs"

conf_path="conf.json.example"
local config_attributes = nil
local config_persistent_attributes = nil

local total_time = 0
N=10000000

function compare_attributes(file_attributes1, file_attributes2)
    if file_attributes1 == nil and file_attributes2 == nil then
        return true
    elseif file_attributes1 == nil and file_attributes2 ~= nil or file_attributes1 ~= nil and file_attributes2 == nil then
        return false
    end
    return file_attributes1["modification"] == file_attributes2["modification"] and file_attributes1["size"] == file_attributes2["size"]
end

function get_config()
    -- Get config files attributes (timestamp modification and size)
    local new_config_attributes = lfs.attributes(conf_path, {"modification", "size"})
    local new_config_persistent_attributes = lfs.attributes(conf_path..".persistent", {"modification", "size"})

    if compare_attributes(new_config_attributes, config_attributes) and compare_attributes(new_config_persistent_attributes, config_persistent_attributes) then
        return conf
    -- If the file is being written, its size may be 0 and reloading fails, return the last valid config
    elseif new_config_attributes == nil or new_config_attributes["size"] == 0 then
        return conf
    end
    print("Reload")
    -- If the timestamp of the modification or the size is different, reload the configuration.
    config_attributes = new_config_attributes
    config_persistent_attributes = new_config_persistent_attributes
    
    local conf_file = assert(io.open(conf_path, "r"), "Configuration file is missing")
    conf = json.decode(conf_file:read("*all"))
    conf_file:close()

    -- Load additional rules from the `.persistent` configuration file.
    -- The `.persistent` file contains rules that will overwrite previous rules.
    -- It typically enables you to set custom rules.
    local persistent_conf_file = io.open(conf_path..".persistent", "r")
    if persistent_conf_file ~= nil then
        perm_conf = json.decode(persistent_conf_file:read("*all"))
        persistent_conf_file:close()
        for k, v in pairs(perm_conf) do

            -- If the configuration key already exists and is a table, merge it
            if conf[k] and type(v) == "table" then
                for subk, subv in pairs(v) do
                    if type(subk) == "number" then
                        table.insert(conf[k], subv)
                    else
                        conf[k][subk] = subv
                    end
                end

            -- Else just take the persistent rule's value
            else
                conf[k] = v
            end
        end
    end

    return conf
end

total_time = 0

for i=1,N do
    get_config()
end
```

This may fail if lua tries to read the persistent file while it is being rewritten.