### PR TITLE
Moar refactoring (on top of permission rework)

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -206,9 +206,10 @@ end
 --
 
 if is_logged_in then
-    assets = {}
-    assets["/ynh_portal.js"] = "js/ynh_portal.js"
-    assets["/ynh_overlay.css"] = "css/ynh_overlay.css"
+    assets = {
+                   ["/ynh_portal.js"] = "js/ynh_portal.js",
+                   ["/ynh_overlay.css"] = "css/ynh_overlay.css"
+             }
     theme_dir = "/usr/share/ssowat/portal/assets/themes/"..conf.theme
     local pfile = io.popen('find "'..theme_dir..'" -type f -exec realpath --relative-to "'..theme_dir..'" {} \\;')
     for filename in pfile:lines() do

--- a/access.lua
+++ b/access.lua
@@ -226,11 +226,12 @@ end
 
 
 --
--- 3. Redirected URLs
+-- 3. REDIRECTED URLS
 --
 -- If the URL matches one of the `redirected_urls` in the configuration file,
 -- just redirect to the target URL/URI
 --
+
 function detect_redirection(redirect_url)
     if hlp.string.starts(redirect_url, "http://")
     or hlp.string.starts(redirect_url, "https://") then

--- a/access.lua
+++ b/access.lua
@@ -265,39 +265,12 @@ if conf["redirected_regex"] then
 end
 
 --
--- 4. Basic HTTP Authentication
 --
--- If the `Authorization` header is set before reaching the SSO, we want to
--- match user and password against the user database.
 --
--- It allows you to bypass the cookie-based procedure with a per-request
--- authentication. Very usefull when you are trying to reach a specific URL
--- via cURL for example.
 --
 
-if not is_logged_in then
-    local auth_header = ngx.req.get_headers()["Authorization"]
 
-    if auth_header then
-        _, _, b64_cred = string.find(auth_header, "^Basic%s+(.+)$")
-        _, _, user, password = string.find(ngx.decode_base64(b64_cred), "^(.+):(.+)$")
-        user = hlp.authenticate(user, password)
-        if user then
-            logger.debug("User got authenticated through basic auth")
 
-            -- If user has no access to this URL, redirect him to the portal
-            if not permission or not hlp.has_access(permission, user) then
-            return hlp.redirect(conf.portal_url)
-            end
-
-            if permission["auth_header"] then
-                logger.debug("Set Headers")
-                hlp.set_headers(user)
-            end
-            return hlp.pass()
-        end
-    end
-end
 
 --
 --

--- a/config.lua
+++ b/config.lua
@@ -60,7 +60,8 @@ function get_config()
         allow_mail_authentication = true,
         default_language          = "en",
         theme                     = "default",
-        logging                   = "fatal" -- Only log fatal messages by default (so apriori nothing)
+        logging                   = "fatal", -- Only log fatal messages by default (so apriori nothing)
+        permissions               = {}
     }
 
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -232,7 +232,7 @@ function refresh_logged_in()
     local authHash = ngx.var.cookie_SSOwAuthHash
 
     authUser = nil
-    
+
     if expireTime and expireTime ~= ""
     and authHash and authHash ~= ""
     and user and user ~= ""
@@ -302,17 +302,18 @@ function has_access(permission, user)
     user = user or authUser
 
     if permission == nil then
+        logger.debug("No permission matching request for "..ngx.var.uri)
         return false
     end
 
     -- Public access
     if user == nil or permission["public"] then
         user = user or "A visitor"
-        logger.debug(user.." tries to access "..ngx.var.uri)
+        logger.debug(user.." tries to access "..ngx.var.uri.." (corresponding perm: "..permission["id"]..")")
         return permission["public"]
     end
 
-    logger.debug("User "..user.." tries to access "..ngx.var.uri)
+    logger.debug("User "..user.." tries to access "..ngx.var.uri.." (corresponding perm: "..permission["id"]..")")
 
     -- All user in this permission
     allowed_users = permission["users"]
@@ -508,7 +509,7 @@ end
 -- It is used to render the SSOwat portal *only*.
 function serve(uri, cache)
 
-    logger.debug("Serving portal uri "..uri.." (if the corresponding file exists)")
+    logger.debug("Serving portal uri "..uri)
 
     rel_path = string.gsub(uri, conf["portal_path"], "/")
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -315,21 +315,26 @@ function has_access(permission, user)
 
     logger.debug("User "..user.." tries to access "..ngx.var.uri.." (corresponding perm: "..permission["id"]..")")
 
-    -- All user in this permission
-    allowed_users = permission["users"]
+    -- The user has permission to access the content if he is in the list of allowed users
+    if element_is_in_table(user, permission["users"]) then
+        logger.debug("User "..user.." can access "..ngx.var.host..ngx.var.uri..uri_args_string())
+        log_access(user, ngx.var.host..ngx.var.uri..uri_args_string())
+        return true
+    else
+        logger.debug("User "..user.." cannot access "..ngx.var.uri)
+        return false
+    end
+end
 
-    -- The user has permission to access the content if he is in the list of this one
-    if allowed_users then
-        for _, u in pairs(allowed_users) do
-            if u == user then
-                logger.debug("User "..user.." can access "..ngx.var.host..ngx.var.uri..uri_args_string())
-                log_access(user, ngx.var.host..ngx.var.uri..uri_args_string())
+function element_is_in_table(element, table)
+    if table then
+        for _, el in pairs(table) do
+            if el == element then
                 return true
             end
         end
     end
 
-    logger.debug("User "..user.." cannot access "..ngx.var.uri)
     return false
 end
 
@@ -646,7 +651,7 @@ function get_data_for(view)
             -- It is typically used to build the app list.
             for permission_name, permission in pairs(conf["permissions"]) do
                 -- We want to display a tile, and uris is not empty
-                if permission['show_tile'] and next(permission['uris']) ~= nil and has_access(permission, user) then
+                if permission['show_tile'] and next(permission['uris']) ~= nil and element_is_in_table(user, permission["users"]) then
                     url = permission['uris'][1]
                     name = permission['label']
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -296,34 +296,6 @@ function log_access(user, uri)
   end
 end
 
-function get_best_permission()
-    if not conf["permissions"] then
-        conf["permissions"] = {}
-    end
-
-    local permission_match = nil
-    local longest_url_match = ""
-    
-    for permission_name, permission in pairs(conf["permissions"]) do
-        if next(permission['uris']) ~= nil then
-            for _, url in pairs(permission['uris']) do
-                if string.starts(url, "re:") then
-                    url = string.sub(url, 4, string.len(url))
-                end
-
-                local m = match(ngx.var.host..ngx.var.uri..uri_args_string(), url)
-                if m ~= nil and string.len(m) > string.len(longest_url_match) then
-                    longest_url_match = m
-                    permission_match = permission
-                    logger.debug("Match "..m)
-                end
-            end
-        end
-    end
-
-    return permission_match
-end
-
 -- Check whether a user is allowed to access a URL using the `permissions` directive
 -- of the configuration file
 function has_access(permission, user)


### PR DESCRIPTION
A bunch of refactoring following review of https://github.com/YunoHost/SSOwat/pull/161

The changes in https://github.com/YunoHost/SSOwat/pull/161 made the code much simpler (way less madness in the handling of unprotected_urls etc...) so I was hoping the whole access.lua code would be easy to read ... but it's still a bit spagetthi because of the whole history of the code

So that's an attempt to make everything even simpler ?

The final structure looks like : 

1. Handle login
2. Handle portal assets
3. Handle redirections (if relevant w.r.t. requested url)
4. Identify most relevant permission to apply
5. Apply permission