### PR TITLE
Change SSOwat auth header to "Proxy-Authorization" to prevent conflict with the app auth header

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -331,12 +331,15 @@ if hlp.has_access(permission) then
 
     return hlp.pass()
 
--- 2nd case : no access ... redirect to portal / login form
+-- 2nd case : no access ... check Authorization header, redirect to portal / login form
 else
 
     if is_logged_in then
         return hlp.redirect(conf.portal_url)
     else
+        -- Check if there is `Authorization` header, and redirect if we have successfully logged in
+        hlp.parse_auth_header()
+
         -- Only display this if HTTPS. For HTTP, we can't know if the user really is
         -- logged in or not, because the cookie is available only in HTTP...
         if ngx.var.scheme == "https" then

--- a/access.lua
+++ b/access.lua
@@ -331,15 +331,12 @@ if hlp.has_access(permission) then
 
     return hlp.pass()
 
--- 2nd case : no access ... check Authorization header, redirect to portal / login form
+-- 2nd case : no access ... redirect to portal / login form
 else
 
     if is_logged_in then
         return hlp.redirect(conf.portal_url)
     else
-        -- Check if there is `Authorization` header, and redirect if we have successfully logged in
-        hlp.parse_auth_header()
-
         -- Only display this if HTTPS. For HTTP, we can't know if the user really is
         -- logged in or not, because the cookie is available only in HTTP...
         if ngx.var.scheme == "https" then

--- a/helpers.lua
+++ b/helpers.lua
@@ -263,14 +263,14 @@ function refresh_logged_in()
     return false
 end
 
--- If client set the `Authorization` header before reaching the SSO,
+-- If client set the `Proxy-Authorization` header before reaching the SSO,
 -- we want to match user and password against the user database.
 --
 -- It allows to bypass the cookie-based procedure with a per-request
 -- authentication. This is useful to authenticate on the SSO during
 -- curl requests for example.
 function parse_auth_header()
-    local auth_header = ngx.req.get_headers()["Authorization"]
+    local auth_header = ngx.req.get_headers()["Proxy-Authorization"]
 
     if auth_header then
         _, _, b64_cred = string.find(auth_header, "^Basic%s+(.+)$")
@@ -295,6 +295,9 @@ function parse_auth_header()
                 else
                     return redirect(conf.portal_url)
                 end
+            else
+                -- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407
+                ngx.status = 407
             end
         end
     end
@@ -426,8 +429,8 @@ end
 -- application underneath.
 function set_headers(user)
     local user = user or authUser
-    -- Set `authorization` header to enable HTTP authentification
-    ngx.req.set_header("Authorization", "Basic "..ngx.encode_base64(
+    -- Set `Proxy-Authorization` header to enable HTTP authentification
+    ngx.req.set_header("Proxy-Authorization", "Basic "..ngx.encode_base64(
       user..":"..cache:get(user.."-password")
     ))
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -429,8 +429,8 @@ end
 -- application underneath.
 function set_headers(user)
     local user = user or authUser
-    -- Set `Proxy-Authorization` header to enable HTTP authentification
-    ngx.req.set_header("Proxy-Authorization", "Basic "..ngx.encode_base64(
+    -- Set `Authorization` header to enable HTTP authentification
+    ngx.req.set_header("Authorization", "Basic "..ngx.encode_base64(
       user..":"..cache:get(user.."-password")
     ))
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -232,6 +232,7 @@ function refresh_logged_in()
     local authHash = ngx.var.cookie_SSOwAuthHash
 
     authUser = nil
+    is_logged_in = false
 
     if expireTime and expireTime ~= ""
     and authHash and authHash ~= ""
@@ -254,13 +255,12 @@ function refresh_logged_in()
                     else
                         authUser = user
                     end
-                    return is_logged_in
                 end
             end
         end
     end
 
-    return false
+    return is_logged_in
 end
 
 -- If client set the `Proxy-Authorization` header before reaching the SSO,

--- a/helpers.lua
+++ b/helpers.lua
@@ -255,52 +255,39 @@ function refresh_logged_in()
                     else
                         authUser = user
                     end
+                    return is_logged_in
                 end
             end
         end
     end
 
-    return is_logged_in
-end
+    -- If client set the `Proxy-Authorization` header before reaching the SSO,
+    -- we want to match user and password against the user database.
+    --
+    -- It allows to bypass the cookie-based procedure with a per-request
+    -- authentication. This is useful to authenticate on the SSO during
+    -- curl requests for example.
 
--- If client set the `Proxy-Authorization` header before reaching the SSO,
--- we want to match user and password against the user database.
---
--- It allows to bypass the cookie-based procedure with a per-request
--- authentication. This is useful to authenticate on the SSO during
--- curl requests for example.
-function parse_auth_header()
     local auth_header = ngx.req.get_headers()["Proxy-Authorization"]
 
     if auth_header then
         _, _, b64_cred = string.find(auth_header, "^Basic%s+(.+)$")
-        if b64_cred ~= nil then
-            _, _, user, password = string.find(ngx.decode_base64(b64_cred), "^(.+):(.+)$")
-            user = authenticate(user, password)
-            if user then
-                logger.debug("User got authenticated through basic auth")
-                is_logged_in = true
-                authUser = user
-
-                if has_access(permission, user) then
-                    refresh_user_cache(user)
-
-                    -- If Basic Authorization header are enable for this permission,
-                    -- add it to the response
-                    if permission["auth_header"] then
-                        set_headers(user)
-                    end
-
-                    return pass()
-                else
-                    return redirect(conf.portal_url)
-                end
-            else
-                -- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407
-                ngx.status = 407
-            end
+        if b64_cred == nil then
+            return is_logged_in
+        end
+        _, _, user, password = string.find(ngx.decode_base64(b64_cred), "^(.+):(.+)$")
+        user = authenticate(user, password)
+        if user then
+            logger.debug("User got authenticated through basic auth")
+            authUser = user
+            is_logged_in = true
+        else
+            -- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407
+            ngx.status = 407
         end
     end
+
+    return is_logged_in
 end
 
 function log_access(user, uri)


### PR DESCRIPTION
CoNtExT: I use nextcloud desktop app which use Auth header with a token instead the user password, and ssowat tries to authenticate using this token I receive a [`Connection failed for:`](https://github.com/YunoHost/SSOwat/blob/75cecb9a7aaacf62a47e3e91fba1248ffc6e578b/helpers.lua#L388) in my error.log and I get banned by fail2ban.

[Before version 4.1](https://github.com/YunoHost/SSOwat/blob/ec2d13439faa7d8ea51609f2d0be9607fa576876/access.lua#L345-L373) we parsed the "auth header" after checking that we don't already have access to the url, [in the 4.1](https://github.com/YunoHost/SSOwat/blob/75cecb9a7aaacf62a47e3e91fba1248ffc6e578b/access.lua#L32) we check auth header on each request.

Solution: Move the auth header check at the end.

Half tested, I no longer get banned by fail2ban because there is auth header, but I'm 100% not sure how to test auth header ><