### PR TITLE
POC: be able to bypass permissions using an admin token

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -327,7 +327,9 @@ function is_admin()
 
   local token = token:gsub("\n","")
 
-  -- FIXME FIXME FIXME - this is a really stupid and time-attack-prone way to validate the token
+  -- LUA comparison are made in constant time thanks to interned string mechanism
+  -- It compare pointers and not char by char. SO no risk of timing attack here :)
+  -- See https://poprocks.dev/constant-time-string-comparison-in-lua/
   if admin_token_header == token then
       return true
   else

--- a/init.lua
+++ b/init.lua
@@ -11,6 +11,7 @@
 -- Path of the configuration
 conf_path = "/etc/ssowat/conf.json"
 log_file = "/var/log/nginx/ssowat.log"
+admin_token_path = "/etc/ssowat/admin_token"
 
 -- Remove prepending '@' & trailing 'init.lua'
 script_path = string.sub(debug.getinfo(1).source, 2, -9)


### PR DESCRIPTION
Soooo today I got fed up of seeing again stuff about having to "unprotect" an app to be able to run some curl requests, then having to protect-it-again-but-we-dont-really-know-if-it-was-protected-or-not-in-the-first-place

That turns a bunch of things that should have been simple into a complex mess.

So instead I'm investigating the idea of : 
- being able to define an admin token to bypass permissions restrictions using a header, let's call it `SSOwat-Admin-Token`
- in `ynh_local_curl`, we temporarily add such a token and inject the corresponding header in the request
- no need to tweak permission before/after ynh_local_curl anymoar
- ???
- PROFIT!

### To test this PR: 

- Pull the corresponding branch, restart nginx
- `install -m 400 -o www-data <(echo secret_token) /etc/ssowat/admin_token`
- install an app in private mode. In my case I installed hextris
- try `curl`ing the page without any auth, this should show the ssowat portal title: `curl -s -L https://yolo.test/hextris --insecure | grep title`
- try adding `--header "SSOwat-Admin-Token: secret_token"`