### PR TITLE
[fix] dash filename, mime types, ynh_userinfo.json

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -208,6 +208,7 @@ end
 if is_logged_in then
     assets = {
                    ["/ynh_portal.js"] = "js/ynh_portal.js",
+                   ["/ynh_userinfo.js"] = "ynh_userinfo.json",
                    ["/ynh_overlay.css"] = "css/ynh_overlay.css"
              }
     theme_dir = "/usr/share/ssowat/portal/assets/themes/"..conf.theme
@@ -218,7 +219,7 @@ if is_logged_in then
     pfile:close()
 
     for shortcut, full in pairs(assets) do
-        if string.match(ngx.var.uri, "^"..shortcut.."$") then
+        if ngx.var.uri == shortcut then
             logger.debug("Serving static asset "..full)
             return hlp.serve("/yunohost/sso/assets/"..full, "static_asset")
         end

--- a/access.lua
+++ b/access.lua
@@ -208,7 +208,7 @@ end
 if is_logged_in then
     assets = {
                    ["/ynh_portal.js"] = "js/ynh_portal.js",
-                   ["/ynh_userinfo.js"] = "ynh_userinfo.json",
+                   ["/ynh_userinfo.json"] = "ynh_userinfo.json",
                    ["/ynh_overlay.css"] = "css/ynh_overlay.css"
              }
     theme_dir = "/usr/share/ssowat/portal/assets/themes/"..conf.theme

--- a/access.lua
+++ b/access.lua
@@ -212,7 +212,7 @@ if is_logged_in then
                    ["/ynh_overlay.css"] = "css/ynh_overlay.css"
              }
     theme_dir = "/usr/share/ssowat/portal/assets/themes/"..conf.theme
-    local pfile = io.popen('find "'..theme_dir..'" -type f -exec realpath --relative-to "'..theme_dir..'" {} \\;')
+    local pfile = io.popen('find "'..theme_dir..'" -not -path "*/\\.*" -type f -exec realpath --relative-to "'..theme_dir..'" {} \\;')
     for filename in pfile:lines() do
         assets["/ynhtheme/"..filename] = "themes/"..conf.theme.."/"..filename
     end

--- a/helpers.lua
+++ b/helpers.lua
@@ -550,13 +550,24 @@ function serve(uri, cache)
         png  = "image/png",
         svg  = "image/svg+xml",
         ico  = "image/vnd.microsoft.icon",
-        woff = "application/x-font-woff",
+        woff = "font/woff",
+        woff2 = "font/woff2",
+        ttf = "font/ttf",
         json = "application/json"
     }
 
+    -- Allow .ms to specify mime type
+    mime = ext
+    if ext == "ms" then
+        subext = string.match(file, "^.+%.(.+)%.ms$")
+        if subext then
+            mime = subext
+        end
+    end
+
     -- Set Content-Type
-    if mime_types[ext] then
-        ngx.header["Content-Type"] = mime_types[ext]
+    if mime_types[mime] then
+        ngx.header["Content-Type"] = mime_types[mime]
     else
         ngx.header["Content-Type"] = "text/plain"
     end
@@ -570,9 +581,10 @@ function serve(uri, cache)
     elseif ext == "ms" then
         local data = get_data_for(file)
         content = lustache:render(content, data)
-    elseif ext == "json" then
+    elseif uri == "/ynh_userinfo.json" then
         local data = get_data_for(file)
         content = json.encode(data)
+        cache = "dynamic"
     end
 
     -- Reset flash messages
@@ -612,7 +624,7 @@ function get_data_for(view)
     elseif view == "portal.html"
         or view == "edit.html"
         or view == "password.html"
-        or view == "ynhpanel.json" then
+        or view == "ynh_userinfo.json" then
 
         -- Invalidate cache before loading these views.
         -- Needed if the LDAP db is changed outside ssowat (from the cli for example).

--- a/helpers.lua
+++ b/helpers.lua
@@ -461,7 +461,7 @@ function refresh_user_cache(user)
     else
         -- Else, just revalidate session for another day by default
         password = cache:get(user.."-password")
-        cache:set(user.."-password", password, conf["session_timeout"])
+        cache:replace(user.."-password", password, conf["session_timeout"])
     end
 end
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -461,6 +461,8 @@ function refresh_user_cache(user)
     else
         -- Else, just revalidate session for another day by default
         password = cache:get(user.."-password")
+        -- Here we don't use set method to avoid strange logout
+        -- See https://github.com/YunoHost/issues/issues/1830
         cache:replace(user.."-password", password, conf["session_timeout"])
     end
 end

--- a/helpers.lua
+++ b/helpers.lua
@@ -277,15 +277,6 @@ function refresh_logged_in()
     return is_logged_in
 end
 
-function log_access(user, uri)
-  local key = "ACC|"..user.."|"..uri
-  local block = cache:get(key)
-  if block == nil then
-    logger.info("User "..user.."@"..ngx.var.remote_addr.." accesses "..uri)
-    cache:set(key, "block", 60)
-  end
-end
-
 -- Check whether a user is allowed to access a URL using the `permissions` directive
 -- of the configuration file
 function has_access(permission, user)
@@ -308,7 +299,6 @@ function has_access(permission, user)
     -- The user has permission to access the content if he is in the list of allowed users
     if element_is_in_table(user, permission["users"]) then
         logger.debug("User "..user.." can access "..ngx.var.host..ngx.var.uri..uri_args_string())
-        log_access(user, ngx.var.host..ngx.var.uri..uri_args_string())
         return true
     else
         logger.debug("User "..user.." cannot access "..ngx.var.uri)


### PR DESCRIPTION
## The problem
I am creating an advanced themes with nice top menu, etc. I discovered several issues:

- Some mime types are missing + we can't specify mime type of .ms
- filename with a dash are not served (and the regex that create this situation might be a security weakness)
- ynh_userinfo.json is broken
- all json are replaced by get_data_for() content ...
- a security risk due to a mechanism that add each uri reached if the app is protected. It was just to display one time an info log (that is already trigger in debug mode...).
- https://github.com/YunoHost/issues/issues/1830

## The solution
This PR fix all of these issues

This PR is found by CNAM