### PR TITLE
Fix auth_header parsing when password contains semicolon

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -276,7 +276,7 @@ function validate_or_clear_basic_auth_header_provided_by_client()
 
     -- Try to authenticate the user,
     -- or remove the Auth header if not valid
-    _, _, user, password = string.find(ngx.decode_base64(b64_cred), "^(.+):(.+)$")
+    _, _, user, password = string.find(ngx.decode_base64(b64_cred), "^([^:]+):(.+)$")
     user = authenticate(user, password)
     if user then
         logger.debug("User got authenticated through basic auth")


### PR DESCRIPTION
If a colon is in the password, user and password are not well detected.
For example if user="me" and password="pass:word" the function give user="me:pass" password="word"