### PR TITLE
Authentication headers are ONLY set when user is logged

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -333,7 +333,11 @@ if hlp.has_access(permission) then
         -- add it to the response
         if permission["auth_header"] then
             hlp.set_headers()
+        else
+            hlp.clear_headers()
         end
+    else
+        hlp.clear_headers()
     end
 
     return hlp.pass()

--- a/helpers.lua
+++ b/helpers.lua
@@ -414,6 +414,16 @@ function set_headers(user)
 
 end
 
+-- Removes the authentication headers. Call me when:
+--   - app is public and user is not authenticated
+--   - app requests that no authentication headers be sent
+-- Prevents user from pretending to be someone else on public apps
+function clear_headers()
+    ngx.req.clear_header("Authorization")
+    for k, v in pairs(conf["additional_headers"]) do
+        ngx.req.clear_header(k)
+    end
+end
 
 function refresh_user_cache(user)
     -- We definitely don't want to pass credentials on a non-encrypted


### PR DESCRIPTION
I don't want to run LDAP logic to authenticate users on my backend app when we already have SSO for that. But i need trust in the HTTP headers sent by SSOWat.

When the app is public, SSOWat previously did not clear authentication headers, leading in a user being able to impersonate someone else.

This PR forces to clear SSOWat headers on apps where the user has permission (includes visitors) but is not logged in, or where the user has permission but the app requested no auth headers in config. It does not change headers in other cases (when user doesn't have permission).