### PR TITLE
Add a new setting to redirect unknown URLs to either the SSO portal or a 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Whether authentication should use secure connection or not (**default**: `https`
 
 ---------------
 
+### err404_to_portal
+
+Wether to redirect unknown URLs to the portal or to a 404 page (**default**: `true`).
+
+---------------
+
 ### domains
 
 List of handled domains (**default**: similar to `portal_domain`).

--- a/access.lua
+++ b/access.lua
@@ -315,9 +315,15 @@ for permission_name, permission_infos in pairs(conf["permissions"]) do
     end
 end
 
+---
+--- 5. REDIRECT TO 404 PAGE IF UNKNOWN URL -> PORTAL IS DISABLED
+---
+if not conf["err404_to_portal"] and longest_url_match == "" then
+    return ngx.exit(ngx.HTTP_NOT_FOUND)
+end
 
 ---
---- 5. CHECK CLIENT-PROVIDED AUTH HEADER (should almost never happen?)
+--- 6. CHECK CLIENT-PROVIDED AUTH HEADER (should almost never happen?)
 ---
 
 if permission ~= nil then
@@ -336,7 +342,7 @@ end
 
 --
 --
--- 6. APPLY PERMISSION
+-- 7. APPLY PERMISSION
 --
 --
 

--- a/conf.json.example
+++ b/conf.json.example
@@ -62,6 +62,7 @@
     },
     "portal_domain": "example.tld",
     "portal_path": "/yunohost/sso/",
+    "err404_to_portal": true,
     "redirected_regex": {
         "example.tld/yunohost[\\/]?$": "https://example.tld/yunohost/sso/"
     },

--- a/config.lua
+++ b/config.lua
@@ -47,7 +47,7 @@ function get_config()
     -- If the timestamp of the modification or the size is different, reload the configuration.
     config_attributes = new_config_attributes
     config_persistent_attributes = new_config_persistent_attributes
-    
+
     local conf_file = assert(io.open(conf_path, "r"), "Configuration file is missing")
     conf = json.decode(conf_file:read("*all"))
     conf_file:close()
@@ -83,6 +83,7 @@ function get_config()
     default_conf = {
         portal_scheme             = "https",
         portal_path               = "/ssowat/",
+        err404_to_portal          = true,
         local_portal_domain       = "yunohost.local",
         domains                   = { conf["portal_domain"], "yunohost.local" },
         session_timeout           = 60 * 60 * 24,     -- one day


### PR DESCRIPTION
My company would like to disable the automatic "unknown url -> SSO portal" redirection. We would prefer a standard 404 web page.

/!\ UNTESTED /!\