### PR TITLE
portal-api: Reintroduce the remote-user header

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -225,6 +225,9 @@ has_access = check_has_access(permission)
 --   the $remote_user var in nginx, typically used by PHP apps
 -- ###########################################################################
 
+-- Remove remote-user header in any case, it will be set again if needed
+ngx.req.clear_header("remote-user")
+
 if permission ~= nil and ngx.req.get_headers()["Authorization"] ~= nil then
     perm_user_remote_user_var_in_nginx_conf = permission["use_remote_user_var_in_nginx_conf"]
     if perm_user_remote_user_var_in_nginx_conf == nil or perm_user_remote_user_var_in_nginx_conf == true then
@@ -277,6 +280,8 @@ if has_access then
         if permission["auth_header"] then
             set_basic_auth_header()
         end
+        -- Set ynh-user again now we checked the user is logged in
+        ngx.req.set_header("remote-user", authUser)
     end
 
     -- Pass


### PR DESCRIPTION
I'm not 100% sure i'm removing the header in the right spot, maybe it should be done earlier? But from quick tests it looks good. Also maybe the header should be renamed to something else but for now it works like it did before (main branch).

I believe the difference is PHP apps don't get `$_SERVER['REMOTE_USER']` when the Authorization is dropped, but i did not test and it's unrelated to this PR.