### PR TITLE
[enh] User doc

### DIFF
--- a/portal/footer.ms
+++ b/portal/footer.ms
@@ -1,7 +1,7 @@
   {{#connected}}
   <div class="ynh-wrapper footer"><nav>
     <a class="link-profile-edit" href="edit.html">{{t_footerlink_edit}}</a>
-    <a class="link-documentation" href="//yunohost.org/docs" target="_blank">{{t_footerlink_documentation}}</a>
+    <a class="link-documentation" href="//yunohost.org/user_guide" target="_blank">{{t_footerlink_documentation}}</a>
     <a class="link-documentation" href="//yunohost.org/help" target="_blank">{{t_footerlink_support}}</a>
     <a class="link-admin" href="/yunohost/admin/" target="_blank">{{t_footerlink_administration}}</a>
   </nav></div>


### PR DESCRIPTION
I suggest the documentation link to redirect onto the user doc and not onto the main doc (used by instances'administrators).