### PR TITLE
Add a way to return 401 instead of redirecting to the SSO login page

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -367,6 +367,11 @@ else
     if is_logged_in then
         return hlp.redirect(conf.portal_url)
     else
+
+        if permission["no_access_behaviour"] == "401" then
+            ngx.exit(ngx.HTTP_UNAUTHORIZED)
+        end
+
         -- Only display this if HTTPS. For HTTP, we can't know if the user really is
         -- logged in or not, because the cookie is available only in HTTP...
         if ngx.var.scheme == "https" then

--- a/conf.json.example
+++ b/conf.json.example
@@ -46,6 +46,17 @@
             ],
             "users": []
         },
+        "myapp.rpc": {
+            "auth_header": false,
+            "label": "MyApp (rpc)",
+            "public": false,
+            "no_access_behaviour": "401",
+            "show_tile": false,
+            "uris": [
+                "re:domain%.tld/%.well%-known/.*"
+            ],
+            "users": []
+        },
         "myapp.main": {
             "auth_header": true,
             "label": "MyApp",


### PR DESCRIPTION
(NB : I don't expect this to be merged right now Aleks :D )

# The problem

Some app clients (looking at you `transmission-remote`) are doing Basic HTTP Auth with libcurl configured to CURLAUTH_ANY. 

Its behaviour is:
* try to run the request with no authentication
  * If it returns a valid HTTP code (20x, 30x), it returns the result to the calling code
  * If it returns a 401 *and* a [`WWW-Authenticate`](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/WWW-Authenticate) header telling what auth method to use
    * libcurl retries the request with the correct auth method

## What's happening with Yunohost SSO ?
We fall in the first case (valid HTTP code, 302, redirect to SSO login) because we usually want that for our human users.
libcurl thus returns the content of the login page instead of getting a WWW-Authenticate method and retrying the authenticated request.

# The solution

I'm still trying to find if a solution can be implemented in "standard" Nginx configuration files. That would invalidate this merge request.

But the solution I suggest is to add a new setting to the ssowat config.json, that tells what behaviour to implement in case of a no-access request.

The `WWW-Authenticate: Basic` header can be specified in the app's nginx configuration file, so I don't add in the ssowat code.