### PR TITLE
Fix cookie check with yunohost on subdomain of other yunohost

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -112,12 +112,39 @@ function check_authentication()
 
     -- cf. src/authenticators/ldap_ynhuser.py in YunoHost to see how the cookie is actually created
 
-    local cookie = ngx.var["cookie_" .. conf["cookie_name"]]
-    if cookie == nil or COOKIE_SECRET == nil then
+    local cookies = ngx.req.get_headers()['Cookie']
+    if COOKIE_SECRET == nil or cookies == nil then
         return false, nil, nil, nil
     end
 
-    session_id, host, user, pwd, headers, err = cached_jwt_verify(cookie, COOKIE_SECRET)
+    -- Note we can't get the cookie from `ngx.var["cookie_" .. conf["cookie_name"]]`
+    -- because this return only the first cookie for a specific name and so if there are multiple yunohost.portal cookie
+    -- we might don't check the good one. By example it could happen if there are 1 Yunohost on a subdomain of an other
+    -- Yunohost. By example we could have have one yunohost on example.com and an other one on hello.example.com.
+    -- In this case, the browser will send 2 cookie for the key yunohost.portal. One for the domain '.example.com' and
+    -- an other one for '.hello.example.com'.
+    -- So we need to parse manually the cookie values
+    local session_id, host, user, pwd, headers, err
+    -- need to check if it's a table
+    -- cf. https://github.com/openresty/lua-nginx-module/issues/710
+    if type(cookies) == "string" then
+        cookies = { cookies }
+    end
+    for _, cookieString in pairs(cookies) do
+        for cookie in string.gmatch(cookieString, "([^;]+)") do
+            cookie = cookie:match("^%s*(.-)%s*$")
+            if cookie:find("^"..conf["cookie_name"].."%s*=" ) ~= nil then
+                local cookieValue = cookie:match("^[^=]*=([^=]+)$"):match("^%s*(.-)%s*$")
+                session_id, host, user, pwd, headers, err = cached_jwt_verify(cookieValue, COOKIE_SECRET)
+                if user ~= nil then
+                    break
+                end
+            end
+        end
+        if user ~= nil then
+            break
+        end
+    end
 
     if err ~= nil then
         return false, nil, nil, nil


### PR DESCRIPTION
# Problem

In case we have one yunohost instance on a subdomain of an other yunohost instance we have a cookie issue with SSOWAT. Note that this issue don't happen with the Yunohost portal API.

By example we have have one yunohost on example.com and an other on hello.example.com.
In this case, the browser will send 2 cookie for the key yunohost.portal. One for the domain '.example.com' and an other one for '.hello.example.com'.

Currently ssowat check the only first cookie, if the first one is the correct one it's good but it could also be the second and in this case the authentication fail.

# Step to reproduce the issue

- Install a yunohost instance on `example.com`.
- Install a yunohost instance on `sub.example.com`.
- Install my_webapp as private app on `sub.example.com` instance.
- Authenticate on the portal `example.com` and on `sub.example.com`.
- Try to access to `sub.example.com`.

You will see that you are redirected to the portal and you can't access to my_webapp because ssowat consider you are not authenticated because it check the wrong cookie. But the yunohost portal API check the good one so you can see the portal.

# Expected

After the authentication you should be able to access to my_webapp.
